### PR TITLE
FIX Don't use actual page instance

### DIFF
--- a/src/SimpleStyleguideController.php
+++ b/src/SimpleStyleguideController.php
@@ -4,6 +4,7 @@ namespace BenManu\SimpleStyleguide;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Security\Permission;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Controllers\ModelAsController;
@@ -64,7 +65,7 @@ class SimpleStyleguideController extends Controller
             Config::inst()->update('SSViewer', 'theme', Subsite::currentSubsite()->Theme);
         }
 
-        $page = SiteTree::get()->first();
+        $page = Injector::inst()->create(SiteTree::class);
         $controller = ModelAsController::controller_for($page);
         $controller->init();
 


### PR DESCRIPTION
Page instances are configured in various ways.
The styleguide controller has it's own Layout template,
and reuses the theme's Page.ss main template.
This can lead to weird situations like showing
content blocks from a random page on top of the
styleguide template, because they happen to be configured on the selected page.

Using Injector::create() is the same logic that's applied in Security controllers
for rendering login forms.