### PR TITLE
Remove Subsites Requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
 		"issues": "https://github.com/benmanu/silverstripe-simple-styleguide/issues"
 	},
 	"require": {
-		"silverstripe/recipe-cms": "^6",
-		"silverstripe/subsites": "^4.0"
+		"silverstripe/recipe-cms": "^6"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^11"


### PR DESCRIPTION
Remove `silverstripe/subsites` requirement from composer.json.

This requirement in composer.json currently installs `silverstripe/subsites` when you install v4.0.0 of this module, which is unnecessary.

As per earlier versions of `silverstripe-simple-styleguide`, `silverstripe/subsites` should not be required.

I assume this requirement was added to ensure the correct version of `silverstripe/subsites` was installed if required by the project, but this will be handled by the `silverstripe/recipe-cms` requirement.